### PR TITLE
Add nanoseconds to IsoDuration (and thus to IsoInterval)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ license = "MIT"
 chrono = "0.4.24"
 nom = "7.1.3"
 thiserror = "1.0.40"
+
+[dev-dependencies]
+rstest = "0.18.1"


### PR DESCRIPTION
Allows user to specify nanoseconds in ISO 8601 intervals, and to use them in Add() and Sub() operations as well.
To specify in string:
```
P3D4H5M6.000000001S
```

This PR also implements `Display` for `IsoDuration`, displaying nanoseconds in the above format.

I want to use this crate as the basis for an Interval type in [Nushell](https:://github.com/nushell).  It currently has a Duration type, [which cannot add months or years to a date accurately](https://github.com/nushell/nushell/pull/9632). 